### PR TITLE
Fix: 회원가입, 비밀번호 찾기 Toast 메세지 수정

### DIFF
--- a/src/components/Authentication/FindPw.tsx
+++ b/src/components/Authentication/FindPw.tsx
@@ -80,6 +80,9 @@ const FindPwForm: React.FC = () => {
             case 'auth/user-not-found':
               setToastMessage('존재하지 않는 이메일입니다.');
               break;
+            case 'auth/invalid-email':
+              setToastMessage('잘못된 이메일 주소입니다.');
+              break;
             default:
               setToastMessage(
                 '알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요.',

--- a/src/components/Authentication/Register.tsx
+++ b/src/components/Authentication/Register.tsx
@@ -175,7 +175,7 @@ const RegisterForm: React.FC = () => {
               setToastMessage('잘못된 이메일 주소입니다.');
               break;
             case 'auth/email-already-in-use':
-              setToastMessage('이미 가입되어 있는 계정입니다.');
+              setToastMessage('이미 사용중인 이메일입니다.');
               break;
             default:
               setToastMessage('알 수 없는 오류가 발생했습니다.');


### PR DESCRIPTION
# 🛠유효성 검사 메세지 추가 & 기존 멘트 수정

## 비교적 간단한 내용이라 사진으로 첨부하겠습니다!
![image](https://github.com/YongYong21/Toy1_team2/assets/122848687/e703a22f-6266-4e3d-adfa-3b6b6caf85f9)

비밀번호 찾기 페이지에서 이메일 양식을 잘못 입력할 시 `ex) 이메일 도메인 뒤 .com이 붙지않는 경우 등등..`

`알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요.` 라는 메세지가 출력되어 

사용자에게 혼란을 줄 여지가 있어 별도로 유효성 검사 case를 추가해주었습니다.

<br/>

![image](https://github.com/YongYong21/Toy1_team2/assets/122848687/d0963100-ac20-4d1e-b305-eaf100ad8754)

마찬가지로, 회원 가입 단계에서도 Firebase DB에 동일한 이메일이 존재할 시 
기존의 `이미 가입되어 있는 계정입니다` 라는 멘트 대신,
`'이미 사용중인 이메일입니다.` 라고 출력될 수 있도록 변경하였습니다!